### PR TITLE
Fix terraform route53 resource

### DIFF
--- a/nubis/terraform/main.tf
+++ b/nubis/terraform/main.tf
@@ -180,7 +180,7 @@ resource "aws_security_group" "elb" {
 
 resource "aws_route53_record" "discovery" {
    zone_id = "${var.zone_id}"
-   name = "${var.region}.${var.domain}"
+   name = "${var.region}"
    type = "A"
    ttl = "30"
    records = ["${aws_instance.bootstrap.private_ip}"]
@@ -188,7 +188,7 @@ resource "aws_route53_record" "discovery" {
 
 resource "aws_route53_record" "ui" {
    zone_id = "${var.zone_id}"
-   name = "ui.${var.region}.${var.domain}"
+   name = "ui.${var.region}"
    type = "CNAME"
    ttl = "30"
    records = ["dualstack.${aws_elb.consul.dns_name}"]

--- a/nubis/terraform/outputs.tf
+++ b/nubis/terraform/outputs.tf
@@ -1,5 +1,5 @@
 output "address" {
-  value = "http://${aws_route53_record.ui.name}/"
+  value = "http://ui.${var.region}.${var.domain}/"
 }
 
 output "discovery" {
@@ -8,7 +8,7 @@ output "discovery" {
 
 # Configure the Consul provider
 provider "consul" {
-    address = "${aws_route53_record.ui.name}:80"
+    address = "ui.${var.region}.${var.domain}:80"
     datacenter = "${var.region}"
     scheme = "http"
 }


### PR DESCRIPTION
Terraform seems to build the `fqdn` out of the `name` and `domain` variable now, so this PR will fix the route53 creation and will stop it from creating an fqdn like: `example.nubis.allizom.org.example.nubis.allizom.org`