### PR TITLE
Get rid of override.tf, now that we can split strings in Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,6 @@ This assumes you are in the project directory
     <edit tfvar files with appropriate info>
     ```
 
-* Configure override file
-
-    ```bash
-    cd nubis/terraform
-    cp override.tf-dist override.tf
-    <edit with appropriate subnet info>
-    ```
-
 * Check if terraform plan gives you the right info (for sanity sake)
 
     ```bash

--- a/nubis/terraform/inputs.tf
+++ b/nubis/terraform/inputs.tf
@@ -89,3 +89,11 @@ variable "acl_default_policy" {
   description = "Default ACL action for anonymous users"
   default = "allow"
 }
+
+variable "public_subnets" {
+  description = "Public Subnets IDs, comma-separated"
+}
+
+variable "private_subnets" {
+  description = "Private Subnets IDs, comma-separated"
+}

--- a/nubis/terraform/main.tf
+++ b/nubis/terraform/main.tf
@@ -34,9 +34,7 @@ EOF
 }
 
 resource "aws_autoscaling_group" "consul" {
-  vpc_zone_identifier = []
-  availability_zones  = []
-
+  vpc_zone_identifier = ["${split(",", var.private_subnets)}"]
   name = "${var.project}-${var.environment}"
   max_size = "${var.servers}"
   min_size = "${var.servers}"
@@ -58,7 +56,7 @@ resource "aws_autoscaling_group" "consul" {
 }
 
 resource "aws_security_group" "consul" {
-  name =   "${var.project}-${var.environment}"
+  name = "${var.project}-${var.environment}"
   description = "Consul internal traffic + maintenance."
 
   vpc_id = "${var.vpc_id}"
@@ -112,7 +110,7 @@ resource "aws_security_group" "consul" {
 # Create a new load balancer
 resource "aws_elb" "consul" {
   name = "elb-${var.project}-${var.environment}"
-  subnets = [ ]
+  subnets = ["${split(",", var.public_subnets)}"]
 
   # This is an internal ELB, only accessible form inside the VPC
   internal = true

--- a/nubis/terraform/override.tf-dist
+++ b/nubis/terraform/override.tf-dist
@@ -1,9 +1,0 @@
-#XXX: Can't have arrays as input variables until TF 0.4
-resource "aws_elb" "consul" {
-  subnets = [ "subnet-xyz", "subnet-xyz", "subnet-xyz" ]
-}
-
-resource "aws_autoscaling_group" "consul" {
-  availability_zones = [ "us-west-2a","us-west-2b","us-west-2c" ]
-  vpc_zone_identifier = [ "subnet-xyz", "subnet-xyz", "subnet-xyz" ]
-}

--- a/nubis/terraform/terraform.tfvars-dist
+++ b/nubis/terraform/terraform.tfvars-dist
@@ -18,4 +18,5 @@ internet_security_group_id = "sg-XXXXXXXX"
 shared_services_security_group_id = "sg-XXXXXXXX"
 https_cert_arn = "arn:aws:iam::xxxxx"
 master_acl_token = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEFFFF0000" # use uuidgen
-manage_iam.us-west-2 = "1" # Default is set to 0, override if you want to have iam roles created
+public_subnets = "subnet-abcd1234,subnet-deed3315"
+private_subnets = "subnet-ddee1122,subnet-eeff1100"


### PR DESCRIPTION
Fixes #73