### PR TITLE
Add a new option :allowed_public_cidrs

### DIFF
--- a/nubis/terraform/inputs.tf
+++ b/nubis/terraform/inputs.tf
@@ -97,3 +97,8 @@ variable "public_subnets" {
 variable "private_subnets" {
   description = "Private Subnets IDs, comma-separated"
 }
+
+variable "allowed_public_cidrs" {
+  description = "Comma separated list of CIDRs with public access"
+  default = "127.0.0.1/32"
+}

--- a/nubis/terraform/outputs.tf
+++ b/nubis/terraform/outputs.tf
@@ -1,3 +1,6 @@
-output "address" {
+output "internal-address" {
   value = "http://${aws_route53_record.ui.fqdn}/"
+}
+output "public-address" {
+  value = "http://${aws_route53_record.public.fqdn}/"
 }

--- a/nubis/terraform/terraform.tfvars-dist
+++ b/nubis/terraform/terraform.tfvars-dist
@@ -20,3 +20,4 @@ https_cert_arn = "arn:aws:iam::xxxxx"
 master_acl_token = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEFFFF0000" # use uuidgen
 public_subnets = "subnet-abcd1234,subnet-deed3315"
 private_subnets = "subnet-ddee1122,subnet-eeff1100"
+public_allowed_cidrs = "10.22.33.44/32"


### PR DESCRIPTION
We now have a public ssl-only ELB that *only* accepts connections
from whitelisted IPs

Fixes #78