### PR TITLE
Pin at a version of solarkennedy/puppet-consul that includes solarkennedy/puppet-consul#208

### DIFF
--- a/nubis/Puppetfile
+++ b/nubis/Puppetfile
@@ -5,5 +5,6 @@ forge "https://forgeapi.puppetlabs.com"
 ##########################################################
 
 # modules from the puppet forge
-mod 'KyleAnderson/consul', '1.0.4'
-
+mod 'KyleAnderson/consul',
+    :git => 'https://github.com/solarkennedy/puppet-consul.git',
+    :ref => 'a84e75c33f71259455375065957ce27098e06d70'


### PR DESCRIPTION
We need a newer version that 1.0.4 of solarkennedy/puppet-consul,
but it isn't available yet, so pin directly at solarkennedy/puppet-consul#208

This finishes fixing #101