### PR TITLE
Determine our bootstrap quorum treshold from the size of our ASG

### DIFF
--- a/nubis/puppet/files/consul-server-bootstrap
+++ b/nubis/puppet/files/consul-server-bootstrap
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# /usr/local/bin isn't set yet in our PATH
+export PATH=/usr/local/bin:$PATH
+
 USER_DATA=$(curl -fqs http://169.254.169.254/latest/user-data)
 eval "$USER_DATA"
 
@@ -10,6 +13,16 @@ CONSUL_DC="${NUBIS_ENVIRONMENT}-${REGION}-${NUBIS_ACCOUNT}"
 # Setup credstash
 CREDSTASH="/usr/local/bin/credstash --region $REGION"
 CREDSTASH_CONTEXT="environment=$NUBIS_ENVIRONMENT region=$REGION service=$NUBIS_PROJECT"
+
+# If we were not told an explicit cluster size via user-data, find it via our ASG
+if [ ! "$CONSUL_BOOTSTRAP_EXPECT" ]; then
+  MY_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+  ASG_NAME=$(aws autoscaling describe-auto-scaling-instances --region "$REGION" --instance "$MY_INSTANCE_ID" --query 'AutoScalingInstances[0].AutoScalingGroupName' --output text)
+  if [ "$ASG_NAME" ]; then
+    # Figure out what the ASG desired capacity (i.e. cluster size) is set at
+    CONSUL_BOOTSTRAP_EXPECT=$(aws autoscaling describe-auto-scaling-groups --region "$REGION" --auto-scaling-group-name "$ASG_NAME" --query 'AutoScalingGroups[0].DesiredCapacity')
+  fi
+fi
 
 if [ "$CONSUL_BOOTSTRAP_EXPECT" ]; then
 cat <<EOF > /etc/consul/zzz-bootstrap.json

--- a/nubis/terraform/main.tf
+++ b/nubis/terraform/main.tf
@@ -26,7 +26,6 @@ NUBIS_ACCOUNT=${var.service_name}
 NUBIS_DOMAIN=${var.domain}
 CONSUL_ACL_DEFAULT_POLICY=${var.acl_default_policy}
 CONSUL_ACL_DOWN_POLICY=${var.acl_down_policy}
-CONSUL_BOOTSTRAP_EXPECT=${var.servers}
 EOF
 }
 


### PR DESCRIPTION
when not told otherwise.

Fixes #72