### PR TITLE
Add confd defaults to set CONSUL_HTTP_TOKEN in confd's environment, if we know of one

### DIFF
--- a/nubis/puppet/confd.pp
+++ b/nubis/puppet/confd.pp
@@ -1,0 +1,21 @@
+# We need to tell confd about the proper ACL to use
+# Unfortunately, confd doesn't natively support this yet
+# https://github.com/kelseyhightower/confd/issues/146
+
+case $::osfamily {
+  default: {
+    $confd_defaults = "/etc/sysconfig/confd"
+  }
+  'Debian': {
+    $confd_defaults = "/etc/default/confd"
+  }
+}
+
+file { $confd_defaults:
+    ensure => file,
+    owner  => root,
+    group  => root,
+    mode   => '0755',
+    source => 'puppet:///nubis/files/confd.defaults',
+}
+

--- a/nubis/puppet/files/confd.defaults
+++ b/nubis/puppet/files/confd.defaults
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -r /etc/consul/zzz-acl.json ]; then
+  CONSUL_HTTP_TOKEN=$(jq -r '.acl_master_token // "anonymous"'  < /etc/consul/zzz-acl.json)
+  export CONSUL_HTTP_TOKEN
+fi

--- a/nubis/puppet/files/confd.defaults
+++ b/nubis/puppet/files/confd.defaults
@@ -1,6 +1,16 @@
 #!/bin/bash
 
+# This gets sourced by confd's init script
+
+# First, see if we have a master ACL token config file
 if [ -r /etc/consul/zzz-acl.json ]; then
-  CONSUL_HTTP_TOKEN=$(jq -r '.acl_master_token // "anonymous"'  < /etc/consul/zzz-acl.json)
-  export CONSUL_HTTP_TOKEN
+  CONSUL_ACL_TOKEN=$(jq -r '.acl_master_token // ""'  < /etc/consul/zzz-acl.json)
+
+  # Should be there, but just in case...
+  if [ "$CONSUL_ACL_TOKEN" != "" ]; then
+    CONSUL_HTTP_TOKEN=$CONSUL_ACL_TOKEN
+
+    # make sure confd gets to see it
+    export CONSUL_HTTP_TOKEN
+  fi
 fi


### PR DESCRIPTION
It's a workaround until confd has actual support for ACL tokens.

Watch https://github.com/kelseyhightower/confd/pull/369 for it

Fixes #152