### PR TITLE
Set the expected number of Consul servers in user-data

### DIFF
--- a/nubis/terraform/multi/main.tf
+++ b/nubis/terraform/multi/main.tf
@@ -55,6 +55,7 @@ NUBIS_ACCOUNT=${var.service_name}
 NUBIS_DOMAIN=${var.domain}
 CONSUL_ACL_DEFAULT_POLICY=${var.acl_default_policy}
 CONSUL_ACL_DOWN_POLICY=${var.acl_down_policy}
+CONSUL_BOOTSTRAP_EXPECT=${var.servers}
 NUBIS_BUMP=${md5("${var.datadog_api_key}${element(template_file.mig.*.rendered,count.index)}")}
 EOF
 }


### PR DESCRIPTION
We used to do that before, but there was also a fallback mechanism
for inferring from the ASG desired size, but this seems broken.

Go back to being explicit until I can figure this out.