### PR TITLE
[dontmerge-yet] Upgrade consul_exporter to version 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ script:
 - nubis/travis/run-checks
 notifications:
   slack:
-    secure: GvXKv17s8B7fxnfHvSg8iQr4LQLsC461bydyA1syy6QexZCl6VIxyVoxBKTgxzvj0c7qCEZHQeUDGg6TumS14dcWaBI0yAQI5usR4g423nsHB7gNC+hLqcnkhXQLHg/kA84HrvzZ+adYPhe8Ywhiy6lvXGj7W4sxVkqQxCzAYwI=
+    secure: GvNKLrsql6mgQPP1Gvwgd3IBvN2d+DKNGmFwhL9eiwWQncOlDZTNMnrG6+6D3sN1iTuvrUiWzefPGzRl+mBnO+63VhpWW0AOsjuVq1U+NPxUisbJMYukyN70uwMG8ZeT4BrUWLb4W3e7mtnoUwcH++pgsuwp45Kd7AKj32bB9KU=

--- a/nubis/puppet/consul_exporter.pp
+++ b/nubis/puppet/consul_exporter.pp
@@ -1,4 +1,4 @@
-$consul_exporter_version = '0.2.0'
+$consul_exporter_version = '0.3.0'
 $consul_exporter_url = "https://github.com/prometheus/consul_exporter/releases/download/${consul_exporter_version}/consul_exporter-${consul_exporter_version}.linux-amd64.tar.gz"
 
 notice ("Grabbing consul_exporter ${consul_exporter_version}")

--- a/nubis/puppet/consul_exporter.pp
+++ b/nubis/puppet/consul_exporter.pp
@@ -1,5 +1,5 @@
 $consul_exporter_version = '0.3.0'
-$consul_exporter_url = "https://github.com/prometheus/consul_exporter/releases/download/${consul_exporter_version}/consul_exporter-${consul_exporter_version}.linux-amd64.tar.gz"
+$consul_exporter_url = "https://github.com/prometheus/consul_exporter/releases/download/v${consul_exporter_version}/consul_exporter-${consul_exporter_version}.linux-amd64.tar.gz"
 
 notice ("Grabbing consul_exporter ${consul_exporter_version}")
 staging::file { "consul_exporter.${consul_exporter_version}.tar.gz":

--- a/nubis/terraform/multi/main.tf
+++ b/nubis/terraform/multi/main.tf
@@ -3,15 +3,13 @@ provider "aws" {
   region  = "${var.aws_region}"
 }
 
-data "atlas_artifact" "nubis-consul" {
-  count = "${var.enabled}"
+module "consul-image" {
+  source = "github.com/nubisproject/nubis-terraform///images?ref=develop"
 
-  name = "nubisproject/nubis-consul"
-  type = "amazon.image"
+  region  = "${var.aws_region}"
+  version = "${var.nubis_version}"
+  project = "nubis-consul"
 
-  metadata {
-    project_version = "${var.nubis_version}"
-  }
 }
 
 resource "aws_launch_configuration" "consul" {
@@ -27,7 +25,7 @@ resource "aws_launch_configuration" "consul" {
   }
 
   name_prefix = "${var.project}-${element(split(",",var.environments), count.index)}-${var.aws_region}-"
-  image_id = "${data.atlas_artifact.nubis-consul.metadata_full["region-${var.aws_region}"]}"
+  image_id = "${module.consul-image.image_id}"
 
   instance_type        = "t2.nano"
   key_name             = "${var.key_name}"


### PR DESCRIPTION
Fixes issue #302

I'm not sure if we rely on any metric here but here are the main change that might break metrics and alerts(from the github page):

 - [CHANGE] Rename service label to service_name in consul_catalog_service_node_healthy metric
 - [CHANGE] Remove redundant consul_catalog_service_nodes metric
 - [CHANGE] Rename consul_agent_check metric to consul_health_node_status

 nubisproject/nubis-prometheus/nubis/puppet/files/nubis.prom has references to `consul_catalog_service_node_healthy` and `consul_agent_check` so we will need to fix them when we do this